### PR TITLE
Multiple store upgrades and price lowering

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -3,6 +3,7 @@ return {
     Debug = true,
     RemoveMaxGodsLimits = true,
     AvoidReplacingTraits = true,
+    LowerShopPrices = true,
     RewardCount = {
         -- Set the reward count for each 'RewardType'.
         Story = 1, -- no effect
@@ -23,9 +24,18 @@ return {
         GiftDrop = 3,
         MetaCurrencyDrop = 3,
         MemPointsCommonDrop = 3,
+        MetaCardPointsCommonDrop = 3,
+        MetaCardPointsCommonBigDrop = 3,
         RoomMoneyDrop = 3,
+        RoomMoneyTinyDrop = 3,
         MaxHealthDrop = 3,
+        MaxHealthDropSmall = 3,
         MaxManaDrop = 3,
+        MaxManaDropSmall = 3,
+        MixerFBossDrop = 3,
+        MixerGBossDrop = 3,
+        MixerHBossDrop = 3,
+        MixerIBossDrop = 3,
         MixerNBossDrop = 3,
         MixerOBossDrop = 3,
         Others = 3 -- the 'Others' is a special key, which does not correspond to any actual drop in the game. It is solely used by mods to denote 'default values'.

--- a/src/config.lua
+++ b/src/config.lua
@@ -7,13 +7,31 @@ return {
     RewardCount = {
         -- Set the reward count for each 'RewardType'.
         Story = 1, -- no effect
-        Shop = 1, -- no effect
         SpellDrop = 1, -- greater than 1 grants more Hex.
         ClockworkGoal = 1, -- when greater than 1, levels will be skipped in the express route.
         TalentDrop = 2, -- keep the setting moderate; too many talent points may prevent closing the talent upgrade interface.
         StackUpgrade = 3, -- this is the Pom rewards count.
         WeaponUpgrade = 3,
         HermesUpgrade = 3,
+        Shop = {
+            DiscountPercent = 67,
+            AphroditeUpgrade = 3,
+            DemeterUpgrade = 3,
+            HephaestusUpgrade = 3,
+            WeaponUpgradeDrop = 3,
+            ShopHermesUpgrade = 3,
+            ShopManaUpgrade = 3,
+            MaxHealthDropBig = 3,
+            StackUpgrade = 3,
+            StoreRewardRandomStack = 3,
+            RoomRewardHealDrop = 2,
+            HealBigDrop = 2,
+            ArmorBoost = 3,
+            WeaponPointsRareDrop = 1,
+            Boon = 3,
+            Consumable = 3,
+            Others = 3
+        },
         Boon = {
             -- These subkeys are 'LootName'.
             HephaestusUpgrade = 3,

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -7,8 +7,8 @@
 -- 	so you will most likely want to have it reference
 --	values and functions later defined in `reload.lua`.
 
-ModUtil.mod.Path.Wrap("DoPatches", function(base)
-	return patch_DoPatches(base)
+ModUtil.mod.Path.Wrap("StartNewRun", function(base, prevRun, args)
+	return patch_StartNewRun(base, prevRun, args)
 end)
 
 ModUtil.mod.Path.Wrap("SpawnRoomReward", function(base, eventSource, args)

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -7,8 +7,16 @@
 -- 	so you will most likely want to have it reference
 --	values and functions later defined in `reload.lua`.
 
+ModUtil.mod.Path.Wrap("DoPatches", function(base)
+	return patch_DoPatches(base)
+end)
+
 ModUtil.mod.Path.Wrap("SpawnRoomReward", function(base, eventSource, args)
 	return patch_SpawnRoomReward(base, eventSource, args)
+end)
+
+ModUtil.mod.Path.Wrap("SpawnStoreItemInWorld", function(base, itemData, kitId)
+	return patch_SpawnStoreItemInWorld(base, itemData, kitId)
 end)
 
 ModUtil.mod.Path.Wrap("ReachedMaxGods", function(base, excludedGods)

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -38,15 +38,18 @@ function patch_StartNewRun(base, prevRun, args)
 
 	printMsg("%s", "HOOKED")
 	if GameState ~= nil and CurrentRun.Hero ~= nil then
+		local storeCostMultiplier = 1 / Config.RewardCount.Others
+		if Config.RewardCount.Shop.Others then storeCostMultiplier = 1 / Config.RewardCount.Shop.Others end
+		local discountConfig = Config.RewardCount.Shop.DiscountPercent
+		if discountConfig and discountConfig >= 0 and discountConfig <= 100 then storeCostMultiplier = (100 - discountConfig) / 100 end
+
 		OverwriteTableKeys(TraitData, {
 			MultiTraitCostReduction = {
 				Hidden = true,
-				Icon = "Keepsake_34",
+				Icon = "Boon_Poseidon_33",
 				InheritFrom = { "BaseTrait" },
 				BlockInRunRarify = true,
-				StoreCostMultiplier = 1 / Config.RewardCount["Shop"],
-				DisplayName = "Titanic Economy",
-      			Description = "All shop prices are massively reduced."
+				StoreCostMultiplier = storeCostMultiplier
 			}
 		})
 		printMsg("%s %s%s", "Added shop price reduction by", tostring(100 - 100 / Config.RewardCount["Shop"]), "%")
@@ -80,8 +83,38 @@ end
 
 function patch_SpawnStoreItemInWorld(base, itemData, kitId)
 	local reward = nil
-	local rewardCount = Config.RewardCount["Shop"];
+	local rewardCount = Config.RewardCount["Others"]
 
+	local boonConfig = Config.RewardCount.Boon
+	local shopConfig = Config.RewardCount.Shop
+	if shopConfig.Others then rewardCount = shopConfig.Others end
+
+	if itemData.Name == "WeaponUpgradeDrop" then
+		if Config.RewardCount.WeaponUpgrade then rewardCount = Config.RewardCount.WeaponUpgrade end
+		if shopConfig.WeaponUpgradeDrop then rewardCount = shopConfig.WeaponUpgradeDrop end
+	elseif itemData.Name =="ShopHermesUpgrade" then
+		if Config.RewardCount.HermesUpgrade then rewardCount = Config.RewardCount.HermesUpgrade end
+		if shopConfig.ShopHermesUpgrade then rewardCount = shopConfig.ShopHermesUpgrade end
+	elseif itemData.Name =="ShopManaUpgrade" then
+		if Config.RewardCount.MaxManaDrop then rewardCount = Config.RewardCount.MaxManaDrop end
+		if shopConfig.ShopManaUpgrade then rewardCount = shopConfig.ShopManaUpgrade end
+	elseif itemData.Type == "Consumable" then
+		if itemData.Name == "BlindBoxLoot" then
+			if shopConfig.Boon then rewardCount = shopConfig.Boon end
+		else
+			if Config.RewardCount[itemData.Name] then rewardCount = Config.RewardCount[itemData.Name] end
+			if shopConfig.Consumable then rewardCount = shopConfig.Consumable end
+			if shopConfig[itemData.Name] then rewardCount = shopConfig[itemData.Name] end
+		end
+	elseif itemData.Type == "Boon" then
+		local boonName = itemData.Name
+		if boonName == "RandomLoot" and itemData.Args and itemData.Args.ForceLootName then boonName = itemData.Args.ForceLootName end
+		if Config.RewardCount[boonName] then rewardCount = boonConfig[boonName] end
+		if shopConfig.Boon then rewardCount = shopConfig.Boon end
+		if shopConfig[boonName] then rewardCount = shopConfig[boonName] end
+	end
+
+	printMsg("%s", dumpTable(itemData))
 	for _ = 1, rewardCount do
 		reward = base(itemData, kitId)
 	end

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -33,12 +33,10 @@ local function getRewardCount(config, rewardType, lootName)
     return v
 end
 
-function patch_DoPatches(base)
-	base()
-	if not Config.LowerShopPrices then
-		return
-	end
+function patch_StartNewRun(base, prevRun, args)
+	local currentRun = base(prevRun, args)
 
+	printMsg("%s", "HOOKED")
 	if GameState ~= nil and CurrentRun.Hero ~= nil then
 		OverwriteTableKeys(TraitData, {
 			MultiTraitCostReduction = {
@@ -54,6 +52,7 @@ function patch_DoPatches(base)
 		ProcessDataInheritance(TraitData.MultiTraitCostReduction, TraitData)
 		AddTrait(CurrentRun.Hero, "MultiTraitCostReduction", "Common")
 	end
+	return currentRun
 end
 
 function patch_SpawnRoomReward(base, eventSource, args)

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -40,6 +40,7 @@ function patch_StartNewRun(base, prevRun, args)
 	if GameState ~= nil and CurrentRun.Hero ~= nil then
 		OverwriteTableKeys(TraitData, {
 			MultiTraitCostReduction = {
+				Hidden = true,
 				Icon = "Keepsake_34",
 				InheritFrom = { "BaseTrait" },
 				BlockInRunRarify = true,

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -37,7 +37,7 @@ function patch_StartNewRun(base, prevRun, args)
 	local currentRun = base(prevRun, args)
 
 	printMsg("%s", "HOOKED")
-	if GameState ~= nil and CurrentRun.Hero ~= nil then
+	if GameState ~= nil and CurrentRun.Hero ~= nil and Config.LowerShopPrices then
 		local storeCostMultiplier = 1 / Config.RewardCount.Others
 		if Config.RewardCount.Shop.Others then storeCostMultiplier = 1 / Config.RewardCount.Shop.Others end
 		local discountConfig = Config.RewardCount.Shop.DiscountPercent

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -33,6 +33,29 @@ local function getRewardCount(config, rewardType, lootName)
     return v
 end
 
+function patch_DoPatches(base)
+	base()
+	if not Config.LowerShopPrices then
+		return
+	end
+
+	if GameState ~= nil and CurrentRun.Hero ~= nil then
+		OverwriteTableKeys(TraitData, {
+			MultiTraitCostReduction = {
+				Icon = "Keepsake_34",
+				InheritFrom = { "BaseTrait" },
+				BlockInRunRarify = true,
+				StoreCostMultiplier = 1 / Config.RewardCount["Shop"],
+				DisplayName = "Titanic Economy",
+      			Description = "All shop prices are massively reduced."
+			}
+		})
+		printMsg("%s %s%s", "Added shop price reduction by", tostring(100 - 100 / Config.RewardCount["Shop"]), "%")
+		ProcessDataInheritance(TraitData.MultiTraitCostReduction, TraitData)
+		AddTrait(CurrentRun.Hero, "MultiTraitCostReduction", "Common")
+	end
+end
+
 function patch_SpawnRoomReward(base, eventSource, args)
 	args = args or {}
     local reward = nil
@@ -53,6 +76,16 @@ function patch_SpawnRoomReward(base, eventSource, args)
         reward = base(eventSource, args)
     end
     return reward
+end
+
+function patch_SpawnStoreItemInWorld(base, itemData, kitId)
+	local reward = nil
+	local rewardCount = Config.RewardCount["Shop"];
+
+	for _ = 1, rewardCount do
+		reward = base(itemData, kitId)
+	end
+	return reward
 end
 
 function patch_ReachedMaxGods(base, excludedGods)


### PR DESCRIPTION
I made multiple rewards spawn in the shop and added config values to target some of the loot types. Additionally shop prices are lowered to make the extra copies affordable (you can control the amount and turn it off). I also added a few more needed config values (focused on ashes and not on psyche).
I would like to customize the way the cost reduction boon is shown (currently there is just placeholder text), but I didn't know how to edit the sjson files on the fly and load them accordingly. Also there is an icon bug for the boon which would crash the game when trying to select it in the boon list. That's why I hid the trait from the list for now.