### PR TITLE
Many small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Multiple story rewards
 - Making rewards optional
+- Making cages optional when rewards are optional
 
 ### Fixed
 

--- a/src/config.lua
+++ b/src/config.lua
@@ -4,9 +4,9 @@ local config = {
     RemoveMaxGodsLimits = true,
     AvoidReplacingTraits = true,
     LowerShopPrices = true,
+    ShopDiscountPercent = 67,
     UpgradesOptional = true,
     CagesOptional = false,
-    ShopDiscountPercent = 67,
     RewardCount = {
         Shop = 1,
         SpellDrop = 1,
@@ -79,6 +79,8 @@ local description = {
     AvoidReplacingTraits = "Now you can have multiple boons of the same slot simultaneously without worrying about the previous ones being replaced.\n现在你可以同时拥有多个相同槽位的恩惠，而不用担心之前的恩惠会被替换掉。",
     LowerShopPrices = "Reduce the price of items in the shop.\n使商店物品的价格降低。",
     ShopDiscountPercent = "Shop discount percentage.\n商店折扣百分比。",
+    UpgradesOptional = "Makes it possible to leave a room without picking up rewards (avoid unwanted boons).",
+    CagesOptional = "When UpgradesOptional is active, makes the interaction with cages optional to avoid cage encounters in the fields completely.",
     RewardCount = {
         -- Set the reward count for each 'RewardType'.
         Story = "No effect\n无效",
@@ -87,18 +89,18 @@ local description = {
         ClockworkGoal = "When greater than 1, levels will be skipped in the express route.\n当大于1时，将在快速通道中跳过若干关卡。",
         TalentDrop = "Keep the setting moderate; too many talent points may prevent closing the talent upgrade interface.\n保持设置适中；太多的天赋点数可能会导致天赋升级界面无法关闭。",
         StackUpgrade = "This is the Pom rewards count.\n这是力量石榴的奖励数量。",
-        WeaponUpgrade = "",
-        HermesUpgrade = "",
+        WeaponUpgrade = "This is the Hammer rewards count.",
+        HermesUpgrade = "This is the Hermes boon count.",
         Boon = {
             -- These subkeys are 'LootName'.
-            HephaestusUpgrade = "",
-            AphroditeUpgrade = "",
-            DemeterUpgrade = "",
-            Others = ""
+            HephaestusUpgrade = "This is the Hephaestus boon count.",
+            AphroditeUpgrade = "This is the Aphrodite boon count.",
+            DemeterUpgrade = "This is the Demeter boon count.",
+            Others = "This is the default boon count."
         },
         Devotion = "",
-        GiftDrop = "",
-        MetaCurrencyDrop = "",
+        GiftDrop = "This is the nectar reward count.",
+        MetaCurrencyDrop = "This is the bones reward count.",
         MemPointsCommonDrop = "This is the psyche reward count.",
         MetaCardPointsCommonDrop = "This is the ashes reward count.",
         MetaCardPointsCommonBigDrop = "",
@@ -118,8 +120,8 @@ local description = {
     },
     ShopItemCount = {
         Boon = {
-            RandomLoot = "",
-            Others = ""
+            RandomLoot = "This is the amount of boons from an unknown god in one shop slot.",
+            Others = "This is the default amount of boons in one shop slot."
         },
         Consumable = {
             ArmorBoost = "",
@@ -127,16 +129,16 @@ local description = {
             MaxHealthDrop = "",
             MaxHealthDropBig = "",
             MaxManaDrop = "",
-            HealBigDrop = "",
+            HealBigDrop = "This is the amount of food in the Tartarus shop.",
             RoomRewardHealDrop = "",
             StackUpgrade = "",
             ShopHermesUpgrade = "",
-            StoreRewardRandomStack = "",
-            CardUpgradePointsDrop = "",
+            StoreRewardRandomStack = "This is the amount of sliced poms (random target).",
+            CardUpgradePointsDrop = "This is the amount of Moondust in one shop slot.",
             MetaCardPointsCommonDrop = "",
             Others = ""
         },
-        Others = ""
+        Others = "This is the default amount of items per shop slot."
     }
 }
 

--- a/src/config.lua
+++ b/src/config.lua
@@ -83,7 +83,6 @@ local description = {
     CagesOptional = "When UpgradesOptional is active, makes the interaction with cages optional to avoid cage encounters in the fields completely.",
     RewardCount = {
         -- Set the reward count for each 'RewardType'.
-        Story = "No effect\n无效",
         Shop = "No effect. Please use the configuration items in 'ShopItemCount' to change the count of items in the shop.\n无效，请使用 ShopItemCount 中的配置项来修改商店物品的数量。",
         SpellDrop = "Greater than 1 grants more Hex.\n大于1时将获得更多咒术。",
         ClockworkGoal = "When greater than 1, levels will be skipped in the express route.\n当大于1时，将在快速通道中跳过若干关卡。",
@@ -97,6 +96,13 @@ local description = {
             AphroditeUpgrade = "This is the Aphrodite boon count.",
             DemeterUpgrade = "This is the Demeter boon count.",
             Others = "This is the default boon count."
+        },
+        Story = {
+            Eris = "Gives you multiple Eris curses in early runs.",
+            Arachne = "Number of dresses from Arachne.",
+            Narcissus = "Number of rewards from Narcissus.",
+            Echo = "Number of rewards from Echo.",
+            Others = "Default number of story rewards.",
         },
         Devotion = "",
         GiftDrop = "This is the nectar reward count.",

--- a/src/config.lua
+++ b/src/config.lua
@@ -5,6 +5,7 @@ local config = {
     AvoidReplacingTraits = true,
     LowerShopPrices = true,
     UpgradesOptional = true,
+    CagesOptional = false,
     ShopDiscountPercent = 67,
     RewardCount = {
         Shop = 1,
@@ -21,6 +22,7 @@ local config = {
             Others = 3
         },
         Story = {
+            Eris = 1,
             Arachne = 2,
             Narcissus = 2,
             Echo = 2,

--- a/src/main.lua
+++ b/src/main.lua
@@ -37,6 +37,7 @@ Config = Chalk.auto 'config.lua'
 -- ^ this updates our `.cfg` file in the config folder!
 public.config = Config -- so other mods can access our config
 
+ActiveCages = 0
 ActiveRewardSpawners = 0
 
 function printMsg(fmt, ...)

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -31,6 +31,10 @@ ModUtil.mod.Path.Wrap("SetTraitTextData", function(base, traitData, args)
 	return patch_SetTraitTextData(base, traitData, args)
 end)
 
+ModUtil.mod.Path.Wrap("SpawnRewardCages", function(base, room, args)
+	return patch_SpawnRewardCages(base, room, args)
+end)
+
 ModUtil.mod.Path.Wrap("LeaveRoom", function(base, currentRun, door)
 	return patch_LeaveRoom(base, currentRun, door)
 end)

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -27,6 +27,14 @@ ModUtil.mod.Path.Wrap("UseLoot", function(base, usee, args, user)
 	return patch_UseLoot(base, usee, args, user)
 end)
 
+ModUtil.mod.Path.Wrap("ErisTakeOff", function(base, eris)
+	return patch_ErisTakeOff(base, eris)
+end)
+
+ModUtil.mod.Path.Wrap("ArtemisExitPresentation", function(base, source, args)
+	return patch_ArtemisExitPresentation(base, source, args)
+end)
+
 ModUtil.mod.Path.Wrap("SetTraitTextData", function(base, traitData, args)
 	return patch_SetTraitTextData(base, traitData, args)
 end)

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -27,6 +27,10 @@ ModUtil.mod.Path.Wrap("UseLoot", function(base, usee, args, user)
 	return patch_UseLoot(base, usee, args, user)
 end)
 
+ModUtil.mod.Path.Wrap("SetTraitTextData", function(base, traitData, args)
+	return patch_SetTraitTextData(base, traitData, args)
+end)
+
 ModUtil.mod.Path.Wrap("LeaveRoom", function(base, currentRun, door)
 	return patch_LeaveRoom(base, currentRun, door)
 end)

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -43,6 +43,10 @@ ModUtil.mod.Path.Wrap("SpawnRewardCages", function(base, room, args)
 	return patch_SpawnRewardCages(base, room, args)
 end)
 
+ModUtil.mod.Path.Wrap("StartFieldsEncounter", function(base, rewardCage, args)
+	return patch_StartFieldsEncounter(base, rewardCage, args)
+end)
+
 ModUtil.mod.Path.Wrap("LeaveRoom", function(base, currentRun, door)
 	return patch_LeaveRoom(base, currentRun, door)
 end)

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -211,11 +211,21 @@ end
 
 function patch_SetTraitTextData(base, traitData, args)
 	if HeroHasTrait(traitData.Name) and (traitData.OldLevel == nil or traitData.NewLevel == nil) then
-		printMsg("Patched level indicators for story reward")
 		traitData.OldLevel = GetTraitCount(CurrentRun.Hero, { TraitData = traitData })
 		traitData.NewLevel = traitData.OldLevel + 1
+		printMsg("Patched level indicators for story reward")
 	end
 	base(traitData, args)
+end
+
+function patch_SpawnRewardCages(base, room, args)
+	base(room, args)
+	printMsg("Unlock check")
+	if CheckRoomExitsReady( room ) then
+		printMsg("Got here")
+		room.ExitsUnlocked = true
+		DoUnlockRoomExits( CurrentRun, room )
+	end
 end
 
 function patch_LeaveRoom(base, currentRun, door)

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -238,7 +238,17 @@ function patch_CreateConsumableItem(base, consumableId, consumableName, costOver
 	if ActiveRewardSpawners > 0 then
 		args.IgnoreSounds = true
 	end
-	return base(consumableId, consumableName, costOverride, args)
+
+	local consumable = base(consumableId, consumableName, costOverride, args)
+
+	-- Make reward accessible for the bow indicators in the fields of mourning
+	if Config.UpgradesOptional then
+		if CurrentRun.CurrentRoom.Using and CurrentRun.CurrentRoom.Using.Spawn and CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" then
+			MapState.OptionalRewards[consumable.ObjectId] = consumable
+		end
+	end
+
+	return consumable
 end
 
 function patch_CheckRoomExitsReady(base, currentRoom)

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -209,6 +209,15 @@ function RefreshNPC(amount, npc)
 	ActiveRewardSpawners = ActiveRewardSpawners - 1
 end
 
+function patch_SetTraitTextData(base, traitData, args)
+	if HeroHasTrait(traitData.Name) and (traitData.OldLevel == nil or traitData.NewLevel == nil) then
+		printMsg("Patched level indicators for story reward")
+		traitData.OldLevel = GetTraitCount(CurrentRun.Hero, { TraitData = traitData })
+		traitData.NewLevel = traitData.OldLevel + 1
+	end
+	base(traitData, args)
+end
+
 function patch_LeaveRoom(base, currentRun, door)
 	killTaggedThreads("MultiTrait_RewardSpawner")
 	ActiveRewardSpawners = 0

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -160,7 +160,7 @@ function SpawnStoreItemCopies(base, originalReward, rewardCount, itemData, kitId
 end
 
 function patch_UseNPC(base, npc, args, user)
-	local NPCsWithRewards = { "Arachne", "Narcissus", "Echo", "Medea", "Icarus", "Circe", "Eris" } --Nemesis, Artemis and Hades are special cases (see patch_UseLoot)
+	local NPCsWithRewards = { Arachne = true, Narcissus = true, Echo = true, Medea = true, Icarus = true, Circe = true, Eris = true } --Nemesis, Artemis and Hades are special cases (see patch_UseLoot)
 	if not NPCsWithRewards[npc.SpeakerName] then
 		base(npc, args, user)
 		return

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -201,6 +201,8 @@ function RefreshNPC(amount, npc)
 			SetNextInteractLines( npc, npc.NextInteractLines )
 		end
 		SetAvailableUseText(npc)
+		-- Refill upgrade options
+		npc.UpgradeOptions = nil
 		printMsg("Use Button refresh activated")
 		waitUntil("MultiTrait_NPCUsed", "MultiTrait_RewardSpawner")
 	end

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -38,7 +38,7 @@ end
 function patch_StartNewRun(base, prevRun, args)
 	local currentRun = base(prevRun, args)
 
-	if GameState ~= nil and CurrentRun.Hero ~= nil and Config.LowerShopPrices then
+	if GameState ~= nil and Game.CurrentRun.Hero ~= nil and Config.LowerShopPrices then
 		local storeCostMultiplier = 1 / Config.ShopItemCount.Others
 		local discountConfig = Config.ShopDiscountPercent
 		if discountConfig and discountConfig >= 0 and discountConfig <= 100 then
@@ -55,7 +55,7 @@ function patch_StartNewRun(base, prevRun, args)
 			}
 		})
 		ProcessDataInheritance(TraitData.MultiTraitCostReduction, TraitData)
-		AddTrait(CurrentRun.Hero, "MultiTraitCostReduction", "Common")
+		AddTrait(Game.CurrentRun.Hero, "MultiTraitCostReduction", "Common")
 
 		printMsg("Added shop price reduction by %s%%", tostring(storeCostMultiplier * 100))
 	end
@@ -236,7 +236,7 @@ end
 
 function patch_SetTraitTextData(base, traitData, args)
 	if HeroHasTrait(traitData.Name) and (traitData.OldLevel == nil or traitData.NewLevel == nil) then
-		traitData.OldLevel = GetTraitCount(CurrentRun.Hero, { TraitData = traitData })
+		traitData.OldLevel = GetTraitCount(Game.CurrentRun.Hero, { TraitData = traitData })
 		traitData.NewLevel = traitData.OldLevel + 1
 		printMsg("Patched level indicators for story reward")
 	end
@@ -250,15 +250,15 @@ function patch_SpawnRewardCages(base, room, args)
 	base(room, args)
 	if CheckRoomExitsReady( room ) then
 		room.ExitsUnlocked = true -- At this point exits ar not initialized, that's why we can just use DoUnlockRoomExits
-		DoUnlockRoomExits( CurrentRun, room )
+		DoUnlockRoomExits( Game.CurrentRun, room )
 	end
 end
 
 function patch_StartFieldsEncounter(base, rewardCage, args)
 	base(rewardCage, args)
 	ActiveCages = ActiveCages - 1
-	if CheckRoomExitsReady(CurrentRun.CurrentRoom) then
-		UnlockRoomExits(CurrentRun, CurrentRun.CurrentRoom)
+	if CheckRoomExitsReady(Game.CurrentRun.CurrentRoom) then
+		UnlockRoomExits(Game.CurrentRun, Game.CurrentRun.CurrentRoom)
 	end
 end
 
@@ -282,7 +282,7 @@ function patch_CreateLoot(base, args)
 	
 	-- Make reward accessible for the bow indicators in the fields of mourning
 	if Config.UpgradesOptional then
-		if CurrentRun.CurrentRoom.Using and CurrentRun.CurrentRoom.Using.Spawn and CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" then
+		if Game.CurrentRun.CurrentRoom.Using and Game.CurrentRun.CurrentRoom.Using.Spawn and Game.CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" then
 			MapState.OptionalRewards[reward.ObjectId] = reward
 		end
 	end
@@ -300,7 +300,7 @@ function patch_CreateConsumableItem(base, consumableId, consumableName, costOver
 
 	-- Make reward accessible for the bow indicators in the fields of mourning
 	if Config.UpgradesOptional then
-		if CurrentRun.CurrentRoom.Using and CurrentRun.CurrentRoom.Using.Spawn and CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" then
+		if Game.CurrentRun.CurrentRoom.Using and Game.CurrentRun.CurrentRoom.Using.Spawn and Game.CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" then
 			MapState.OptionalRewards[consumable.ObjectId] = consumable
 		end
 	end


### PR DESCRIPTION
Issues fixed:

- Consumables in cages were not shown by bow indicators when UpgradesOptional was true
- Multiple rewards from Hades always had the same set of choices
- Exit doors were not checked without interacting with a reward
- You were able to interact with non-reward-giving NPCs multiple times too
- Artemis and Eris triggered despawn animation right after interaction

Issues diminished:

- Level indicators on duplicate boons now always show Lv. 1 -> Lv. 2 (which is not optimal, but better than before)

Changes:

- Added option for optional reward cages, so that you can be forced to fight the encounters in the fields even when rewards are optional

Comments:

- Some story rewards are clearly not designed for multiple rewards and it is questionable to allow copies of them (just get to be untouchable with **Evade** Evade _Evade_)
- With these changes the mod has to be updated once the final story encounter is introduced