### PR TITLE
Made reward spawning object specific and faster

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -37,6 +37,7 @@ Config = Chalk.auto 'config.lua'
 -- ^ this updates our `.cfg` file in the config folder!
 public.config = Config -- so other mods can access our config
 
+SignalPrefix = "Abevol-MultiReward"
 ActiveCages = 0
 ActiveRewardSpawners = 0
 

--- a/src/ready.lua
+++ b/src/ready.lua
@@ -7,6 +7,12 @@
 -- 	so you will most likely want to have it reference
 --	values and functions later defined in `reload.lua`.
 
+OnUsed{
+	function(triggerArgs)
+		patch_OnUsed(triggerArgs)
+	end
+}
+
 ModUtil.mod.Path.Wrap("StartNewRun", function(base, prevRun, args)
 	return patch_StartNewRun(base, prevRun, args)
 end)

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -300,7 +300,7 @@ function patch_CreateConsumableItem(base, consumableId, consumableName, costOver
 
 	-- Make reward accessible for the bow indicators in the fields of mourning
 	if Config.UpgradesOptional then
-		if Game.CurrentRun.CurrentRoom.Using and Game.CurrentRun.CurrentRoom.Using.Spawn and Game.CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" then
+		if Game.CurrentRun.CurrentRoom.Using and Game.CurrentRun.CurrentRoom.Using.Spawn and Game.CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" and not consumable.Name == "ManaDropMinorPoseidon" then
 			MapState.OptionalRewards[consumable.ObjectId] = consumable
 		end
 	end

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -35,11 +35,22 @@ local function getRewardCount(config, rewardType, lootName)
     return v
 end
 
+local function getSignalName(signalName, objectId)
+	local prefixedSignalName = SignalPrefix.."_"..signalName
+	if objectId then
+		prefixedSignalName = prefixedSignalName.."_"..objectId
+	end
+	return prefixedSignalName
+end
+
+local function getTagName(tagName, objectId)
+	return getSignalName(tagName, objectId)
+end
+
 local function waitForRewardUse(reward)
 	if reward == nil then return end
 	reward.NotifyName = "OnUsed"..reward.ObjectId
-	local customSignalName = "MultiTrait_OnUsed"..reward.ObjectId
-	waitUntil(customSignalName, "MultiTrait_RewardSpawner")
+	waitUntil(getSignalName("OnUsed", reward.ObjectId), getTagName("RewardSpawner"))
 end
 
 function patch_OnUsed(triggerArgs)
@@ -53,9 +64,9 @@ function patch_OnUsed(triggerArgs)
 
 	if usee.OnUsedGameStateRequirements == nil or IsGameStateEligible(CurrentRun, usee, usee.OnUsedGameStateRequirements) then
 		if usee.NotifyName ~= nil and usee.ObjectId then
-			local signalName = "MultiTrait_OnUsed"..usee.ObjectId
-			notifyExistingWaiters(signalName)
-			printMsg("Triggered %s", signalName)
+			local customSignalName = getSignalName("OnUsed", usee.ObjectId)
+			notifyExistingWaiters(customSignalName)
+			printMsg("Triggered %s", customSignalName)
 		end
 	end
 end
@@ -112,7 +123,7 @@ function patch_SpawnRoomReward(base, eventSource, args)
 	thread(SpawnRewardCopies, base, reward, rewardCount - 1, eventSource, args)
 
 	if waitForLast then
-		waitUntil("MultiTrait_AllRewardsAcquired")
+		waitUntil(getSignalName("AllRewardsAcquired"))
 	end
     return reward
 end
@@ -130,7 +141,7 @@ function SpawnRewardCopies(base, originalReward, rewardCount, eventSource, args)
 	
 	-- Wait once more before unlocking the door
 	waitForRewardUse(reward)
-	notifyExistingWaiters("MultiTrait_AllRewardsAcquired")
+	notifyExistingWaiters(getSignalName("AllRewardsAcquired"))
 	ActiveRewardSpawners = ActiveRewardSpawners - 1
 end
 
@@ -173,7 +184,7 @@ function patch_UseNPC(base, npc, args, user)
 	if ActiveRewardSpawners == 0 then
 		thread(RefreshNPC, rewardCount - 1, npc)
 	else 
-		notifyExistingWaiters("MultiTrait_NPCUsed")
+		notifyExistingWaiters(getSignalName("NPCUsed"))
 	end
 end
 
@@ -190,7 +201,7 @@ function patch_UseLoot(base, usee, args, user)
 	if ActiveRewardSpawners == 0 then
 		thread(RefreshNPC, rewardCount - 1, usee)
 	else 
-		notifyExistingWaiters("MultiTrait_NPCUsed")
+		notifyExistingWaiters(getSignalName("NPCUsed"))
 	end
 end
 
@@ -209,15 +220,15 @@ function RefreshNPC(amount, npc)
 		-- Refill upgrade options
 		npc.UpgradeOptions = nil
 		printMsg("NPC refreshed")
-		waitUntil("MultiTrait_NPCUsed", "MultiTrait_RewardSpawner")
+		waitUntil(getSignalName("NPCUsed"), getTagName("RewardSpawner"))
 	end
 	ActiveRewardSpawners = ActiveRewardSpawners - 1
-	notifyExistingWaiters("MultiTrait_AllNPCRewardsAcquired")
+	notifyExistingWaiters(getSignalName("AllNPCRewardsAcquired"))
 end
 
 function patch_ErisTakeOff(base, eris)
 	if ActiveRewardSpawners > 0 or getRewardCount(Config.RewardCount.Story, "Eris") > 1 then
-		waitUntil("MultiTrait_AllNPCRewardsAcquired", "MultiTrait_NPCHandler")
+		waitUntil(getSignalName("AllNPCRewardsAcquired"), getTagName("NPCHandler"))
 	end
 	base(eris)
 end
@@ -231,7 +242,7 @@ function patch_ArtemisExitPresentation(base, source, args)
 end
 
 function ArtemisThreadedExit(base, source, args)
-	waitUntil("MultiTrait_AllNPCRewardsAcquired", "MultiTrait_NPCHandler")
+	waitUntil(getSignalName("AllNPCRewardsAcquired"), getTagName("NPCHandler"))
 	base(source, args)
 end
 
@@ -264,8 +275,8 @@ function patch_StartFieldsEncounter(base, rewardCage, args)
 end
 
 function patch_LeaveRoom(base, currentRun, door)
-	killTaggedThreads("MultiTrait_RewardSpawner")
-	killTaggedThreads("MultiTrait_NPCHandler")
+	killTaggedThreads(getTagName("RewardSpawner"))
+	killTaggedThreads(getTagName("NPCHandler"))
 	ActiveCages = 0
 	ActiveRewardSpawners = 0
 	base(currentRun, door)

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -315,7 +315,7 @@ function patch_CreateConsumableItem(base, consumableId, consumableName, costOver
 
 	-- Make reward accessible for the bow indicators in the fields of mourning
 	if Config.UpgradesOptional then
-		if Game.CurrentRun.CurrentRoom.Using and Game.CurrentRun.CurrentRoom.Using.Spawn and Game.CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" and not consumable.Name == "ManaDropMinorPoseidon" then
+		if Game.CurrentRun.CurrentRoom.Using and Game.CurrentRun.CurrentRoom.Using.Spawn and Game.CurrentRun.CurrentRoom.Using.Spawn == "FieldsRewardCage" and consumable.Name ~= "ManaDropMinorPoseidon" then
 			MapState.OptionalRewards[consumable.ObjectId] = consumable
 		end
 	end

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -141,12 +141,8 @@ function SpawnRewardCopies(base, originalReward, rewardCount, eventSource, args)
 	
 	-- Wait for last boon choice selection
 	if reward ~= nil then
-		if reward.MenuNotify ~= nil then
-			waitUntil(UIData.BoonMenuId, getTagName("RewardSpawner"))
-		else
-			reward.NotifyName = "OnUsed"..reward.ObjectId
-			waitUntil(reward.NotifyName, getTagName("RewardSpawner"))
-		end
+		reward.NotifyName = "OnUsed"..reward.ObjectId
+		waitUntil(reward.NotifyName, getTagName("RewardSpawner"))
 	end
 	notifyExistingWaiters(getSignalName("AllRewardsAcquired"))
 	ActiveRewardSpawners = ActiveRewardSpawners - 1

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -139,8 +139,15 @@ function SpawnRewardCopies(base, originalReward, rewardCount, eventSource, args)
         reward = base(eventSource, args)
     end
 	
-	-- Wait once more before unlocking the door
-	waitForRewardUse(reward)
+	-- Wait for last boon choice selection
+	if reward ~= nil then
+		if reward.MenuNotify ~= nil then
+			waitUntil(UIData.BoonMenuId, getTagName("RewardSpawner"))
+		else
+			reward.NotifyName = "OnUsed"..reward.ObjectId
+			waitUntil(reward.NotifyName, getTagName("RewardSpawner"))
+		end
+	end
 	notifyExistingWaiters(getSignalName("AllRewardsAcquired"))
 	ActiveRewardSpawners = ActiveRewardSpawners - 1
 end


### PR DESCRIPTION
Issues fixed:

- Bow now no longer shows spirit bubbles from Poseidon's mana boon
- Reward copies now only spawn for used reward in fields rooms with cages and shops

Changes:

- Created custom event with cautious OnUse engine hook to make copy spawns faster and object specific